### PR TITLE
Add "diff" banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # The source of https://ruby-gnome.github.io/
 
+![logo](https://avatars1.githubusercontent.com/u/416159)
+
 ## License
 
 Copyright (c)  2003-2022  Ruby-GNOME Project.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The source of https://ruby-gnome.github.io/
 
-![logo](https://avatars1.githubusercontent.com/u/416159)
+![logo](https://github.com/ruby-gnome/ruby-gnome/blob/master/gtk3/sample/gtk-demo/ruby-gnome2-logo.png)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # The source of https://ruby-gnome.github.io/
 
+```diff
+- The old wiki has been lost.
++ Here is the new page.
+```
+
 ![logo](https://github.com/ruby-gnome/ruby-gnome/blob/master/gtk3/sample/gtk-demo/ruby-gnome2-logo.png)
 
 ## API Rerefence


### PR DESCRIPTION
> Maybe we should replace the links and put up a banner that says the previous page is gone?

This is `concept art` pull request for https://github.com/ruby-gnome/ruby-gnome/discussions/1470#discussioncomment-2618613