### PR TITLE
Add link to source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Open source
 
-- [Github](https://github.com/ruby-gnome/ruby-gnome)
+- [GitHub](https://github.com/ruby-gnome/ruby-gnome)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 * [dev](https://ruby-gnome.github.io/ruby-gnome/doc/dev/)
 * [latest](https://ruby-gnome.github.io/ruby-gnome/doc/latest/)
 
-## Open source
+## Source Code
 
 - [GitHub](https://github.com/ruby-gnome/ruby-gnome)
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 * [dev](https://ruby-gnome.github.io/ruby-gnome/doc/dev/)
 * [latest](https://ruby-gnome.github.io/ruby-gnome/doc/latest/)
 
+## Open source
+
+- [Github](https://github.com/ruby-gnome/ruby-gnome)
+
 ## License
 
 Copyright (c)  2003-2022  Ruby-GNOME Project.


### PR DESCRIPTION
Hi!

I found that there is no link to jump to the ruby-gnome source code repository from the [gem page](https://rubygems.org/gems/webkit2-gtk/).

This PR will allow easier access to the source code.
Thanks