### PR TITLE
Fix logo is not shown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The source of https://ruby-gnome.github.io/
 
-![logo](https://github.com/ruby-gnome/ruby-gnome/blob/master/gtk3/sample/gtk-demo/ruby-gnome2-logo.png)
+![logo](https://raw.githubusercontent.com/ruby-gnome/ruby-gnome/master/gtk3/sample/gtk-demo/ruby-gnome2-logo.png)
 
 ## API Rerefence
 


### PR DESCRIPTION
`content-type` should be `image/png`.

Please refer to the command below. I omitted unnecessary response headers.

```sh
$ curl -I https://github.com/ruby-gnome/ruby-gnome/blob/master/gtk3/sample/gtk-demo/ruby-gnome2-logo.png
HTTP/2 200
content-type: text/html; charset=utf-8

$ curl -I https://raw.githubusercontent.com/ruby-gnome/ruby-gnome/master/gtk3/sample/gtk-demo/ruby-gnome2-logo.png
HTTP/2 200
content-type: image/png
```

This fixes the issue #10.